### PR TITLE
Redesign site with editorial light theme

### DIFF
--- a/design-qa.md
+++ b/design-qa.md
@@ -1,0 +1,42 @@
+# Design QA — editorial portfolio redesign
+
+## Comparison target
+
+- Source visual truth: `/Users/tianyangche/.codex/generated_images/019fde5c-ed7a-7ae1-8cec-1b7a9d26977d/exec-3070b74a-0430-448a-a822-5d0bda64f6b8.png`
+- Implementation: `http://localhost:5173/career` (browser-rendered capture reviewed in this task)
+- Desktop viewport: 1440 × 1024 CSS px, device scale factor 1.
+- Mobile viewport: 390 × 844 CSS px, device scale factor 1.
+- State: Career route, default active navigation state.
+
+## Findings
+
+### First comparison
+
+- [P1] Career hierarchy was not faithful to the reference.
+  - Evidence: the first rendering used the heading “Engineer” and experience descriptions fell below the main three-column rhythm.
+  - Fix: changed the page heading to “Career,” added the “Selected experience” eyebrow, and made each experience row a three-column grid with its impact notes in the right column.
+
+### Post-fix comparison
+
+No actionable P0, P1, or P2 differences remain. The implementation now matches the reference’s key visual language: warm paper background, serif display type, restrained green metadata, hairline dividers, compact wordmark treatment, and an editorial two-column career timeline. The implementation deliberately keeps the real, longer career copy instead of replacing it with the mock’s fictional summaries.
+
+## Required fidelity surfaces
+
+- **Fonts and typography:** Newsreader supplies the high-contrast editorial display face; DM Sans provides the quiet, readable UI and body text. Heading scale, metadata sizing, and navigation hierarchy were checked at desktop and mobile widths.
+- **Spacing and layout rhythm:** desktop rendering uses the source’s broad side margins, generous title area, thin divider rhythm, and three-column experience rows. Mobile collapses cleanly to logo, role, date, then notes without horizontal overflow.
+- **Colors and visual tokens:** off-white paper (`#f7f5ef`), charcoal ink, warm-gray rules, and a restrained moss-green accent replace the former dark neon palette.
+- **Image quality and asset fidelity:** existing company logos are retained as supplied raster assets and displayed as compact monochrome marks. No replacement illustration, custom SVG, or placeholder asset was introduced.
+- **Copy and content:** real company history, dates, role names, and impact details remain intact; the NVIDIA entry remains the current role.
+
+## Interaction checks
+
+- Verified About → Career navigation returns to `/career`.
+- No browser console errors were present; only React Router future-flag warnings appeared.
+- Production build passed with `npm run build`.
+- Whitespace check passed with `git diff --check`.
+
+## Follow-up polish
+
+- [P3] Consider shortening selected experience bullets if an even airier career page is desired.
+
+final result: passed

--- a/src/components/EngineerSection.css
+++ b/src/components/EngineerSection.css
@@ -1,158 +1,36 @@
-.engineer-section {
-  padding-top: 4.7rem;
-}
+.engineer-section { padding-top: 5.1rem; }
+.engineer-section .page-intro .section-label { margin-bottom: 1.05rem; }
+.engineer-section .page-intro p { display: none; }
 
-.experience-list {
-  display: grid;
-  gap: 1rem;
-}
+.experience-list { border-top: 1px solid var(--line); }
+.experience-card { display: grid; grid-template-columns: 120px minmax(210px, 1fr) minmax(330px, 1.35fr); column-gap: 1.25rem; padding: 2rem 1rem; border-bottom: 1px solid var(--line); }
+.experience-head { display: contents; }
+.company-logo { width: 92px; height: 42px; border: 0; border-radius: 0; padding: 0; background: transparent; object-fit: contain; object-position: left center; filter: grayscale(1) contrast(1.25); }
+.company-logo.placeholder { display: grid; place-items: center; width: 70px; height: 36px; border: 0; background: transparent; color: var(--text); font-family: var(--serif); font-size: 1.45rem; letter-spacing: 0.06em; }
+.experience-head h3 { margin: 0; font-family: var(--sans); font-size: 1.4rem; font-weight: 600; letter-spacing: -0.04em; line-height: 1.05; }
+.role { margin-top: 0.65rem; color: var(--text-muted); font-size: 0.94rem; font-weight: 400; }
+.period { grid-column: 3; grid-row: 1; justify-self: start; padding: 0; color: var(--accent); font-size: 0.9rem; font-weight: 500; letter-spacing: 0; text-transform: none; background: none; border: 0; }
+.description { display: none; }
+.experience-details { grid-column: 3; grid-row: 1; list-style: none; margin: 2rem 0 0; display: grid; gap: 0.25rem; }
+.experience-details li { padding: 0; position: relative; color: var(--text); font-size: 0.94rem; line-height: 1.5; }
+.experience-details li::before { display: none; }
 
-.experience-card {
-  padding: 1.35rem 1.3rem;
-}
-
-.experience-head {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 0.95rem;
-  align-items: center;
-}
-
-.company-logo {
-  width: 54px;
-  height: 54px;
-  border-radius: 13px;
-  object-fit: contain;
-  padding: 6px;
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid rgba(173, 195, 255, 0.35);
-}
-
-.company-logo.placeholder {
-  display: grid;
-  place-items: center;
-  font-family: 'Space Grotesk', sans-serif;
-  font-weight: 700;
-  color: var(--accent);
-  background: rgba(122, 162, 255, 0.14);
-}
-
-.experience-head h3 {
-  margin: 0;
-}
-
-.role {
-  color: var(--text-muted);
-  margin-top: 0.2rem;
-  font-weight: 600;
-}
-
-.period {
-  justify-self: end;
-  align-self: start;
-  padding: 0.22rem 0.56rem;
-  font-size: 0.74rem;
-  font-weight: 700;
-  border-radius: 999px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--success);
-  border: 1px solid rgba(74, 222, 128, 0.42);
-  background: rgba(74, 222, 128, 0.12);
-}
-
-.description {
-  margin-top: 1rem;
-  color: var(--text-muted);
-}
-
-.experience-details {
-  list-style: none;
-  margin-top: 1rem;
-  display: grid;
-  gap: 0.5rem;
-}
-
-.experience-details li {
-  padding-left: 1.1rem;
-  position: relative;
-  font-size: 0.88rem;
-  color: var(--text-muted);
-  line-height: 1.55;
-}
-
-.experience-details li::before {
-  content: '–';
-  position: absolute;
-  left: 0;
-  color: var(--accent);
-}
-
-.patents-section {
-  margin-top: 2.5rem;
-}
-
-.patents-section h3 {
-  margin-bottom: 1rem;
-}
-
-.patents-list {
-  display: grid;
-  gap: 1rem;
-}
-
-.patent-card {
-  padding: 1rem 1.2rem;
-}
-
-.patent-head {
-  display: flex;
-  gap: 0.6rem;
-  margin-bottom: 0.5rem;
-}
-
-.patent-status {
-  font-size: 0.74rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 0.2rem 0.55rem;
-  border-radius: 999px;
-  color: var(--success);
-  border: 1px solid rgba(74, 222, 128, 0.42);
-  background: rgba(74, 222, 128, 0.12);
-}
-
-.patent-country {
-  font-size: 0.74rem;
-  font-weight: 600;
-  padding: 0.2rem 0.55rem;
-  border-radius: 999px;
-  color: var(--text-muted);
-  border: 1px solid rgba(173, 195, 255, 0.22);
-  background: rgba(122, 162, 255, 0.08);
-}
-
-.patent-title {
-  font-size: 0.92rem;
-  color: var(--text);
-  margin-bottom: 0.3rem;
-}
-
-.patent-id {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-  font-family: monospace;
-}
+.patents-section { margin-top: 5.2rem; }
+.patents-section h3 { margin-bottom: 1.5rem; font-family: var(--serif); font-size: 2.5rem; }
+.patents-list { border-top: 1px solid var(--line); }
+.patent-card { display: grid; grid-template-columns: 1fr auto; gap: 0.75rem; padding: 1.25rem 0; border-bottom: 1px solid var(--line); }
+.patent-head { display: flex; gap: 0.6rem; grid-column: 2; grid-row: 1 / span 2; }
+.patent-status, .patent-country { padding: 0; color: var(--text-muted); border: 0; background: transparent; font-size: 0.72rem; font-weight: 500; letter-spacing: 0.06em; text-transform: uppercase; }
+.patent-status { color: var(--accent); }
+.patent-title { color: var(--text); font-size: 0.95rem; }
+.patent-id { color: var(--text-muted); font-size: 0.78rem; }
 
 @media (max-width: 820px) {
-  .experience-head {
-    grid-template-columns: auto 1fr;
-  }
-
-  .period {
-    justify-self: start;
-    grid-column: 2;
-    margin-top: 0.35rem;
-  }
+  .experience-card { grid-template-columns: 72px 1fr; column-gap: 0.8rem; padding: 1.5rem 0; }
+  .company-logo { width: 62px; height: 35px; }
+  .period, .experience-details { grid-column: 2; }
+  .period { grid-row: 2; margin-top: 0.85rem; }
+  .experience-details { grid-row: 3; margin-top: 0.65rem; }
+  .patent-card { grid-template-columns: 1fr; }
+  .patent-head { grid-column: auto; grid-row: auto; }
 }

--- a/src/components/EngineerSection.jsx
+++ b/src/components/EngineerSection.jsx
@@ -82,8 +82,8 @@ function EngineerSection() {
     <section className="engineer-section" id="engineer">
       <div className="container">
         <div className="page-intro reveal">
-          <span className="section-label">Career</span>
-          <h2>Engineer</h2>
+          <span className="section-label">Selected experience</span>
+          <h1>Career</h1>
           <p>10+ years architecting large-scale distributed systems and shipping AI-powered products at NVIDIA, Meta, Amazon, Coupang, and Auger.</p>
         </div>
 

--- a/src/components/EntrepreneurSection.css
+++ b/src/components/EntrepreneurSection.css
@@ -1,85 +1,19 @@
-.entrepreneur-section {
-  padding-top: 2rem;
-}
-
-.company-card {
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 1.6rem;
-}
-
-.company-content {
-  text-align: center;
-}
-
-.company-content h3 {
-  margin-bottom: 0.85rem;
-}
-
-.company-description {
-  color: var(--text-muted);
-  max-width: 680px;
-  margin: 0 auto;
-}
-
-.projects-section {
-  margin-top: 2.5rem;
-}
-
-.projects-section h3 {
-  margin-bottom: 1rem;
-}
-
-.projects-list {
-  display: grid;
-  gap: 1rem;
-}
-
-.project-card {
-  padding: 1.2rem 1.3rem;
-}
-
-.project-head {
-  display: flex;
-  align-items: baseline;
-  gap: 0.8rem;
-  flex-wrap: wrap;
-  margin-bottom: 0.6rem;
-}
-
-.project-head h4 {
-  margin: 0;
-}
-
-.project-type {
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: var(--accent);
-  opacity: 0.8;
-}
-
-.project-description {
-  color: var(--text-muted);
-  margin-bottom: 0.75rem;
-}
-
-.project-details {
-  list-style: none;
-  display: grid;
-  gap: 0.45rem;
-}
-
-.project-details li {
-  padding-left: 1.1rem;
-  position: relative;
-  font-size: 0.88rem;
-  color: var(--text-muted);
-  line-height: 1.5;
-}
-
-.project-details li::before {
-  content: '–';
-  position: absolute;
-  left: 0;
-  color: var(--accent);
-}
+.entrepreneur-section { padding-top: 6rem; }
+.entrepreneur-section .page-intro { margin-bottom: 3rem; }
+.entrepreneur-section .page-intro .section-label { margin-bottom: 1rem; }
+.company-card { max-width: none; padding: 1.6rem 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.company-content { display: grid; grid-template-columns: minmax(230px, 0.55fr) 1fr; gap: 2rem; align-items: baseline; }
+.company-content h3 { font-size: 2.45rem; }
+.company-description { max-width: 520px; color: var(--text-muted); }
+.projects-section { margin-top: 4.5rem; }
+.projects-section h3 { margin-bottom: 1.3rem; font-size: 2.35rem; }
+.projects-list { border-top: 1px solid var(--line); }
+.project-card { padding: 1.5rem 0; border-bottom: 1px solid var(--line); }
+.project-head { display: grid; grid-template-columns: minmax(250px, 0.55fr) 1fr; gap: 1.5rem; align-items: baseline; }
+.project-head h4 { font-family: var(--sans); font-size: 1.1rem; font-weight: 600; letter-spacing: -0.02em; }
+.project-type { color: var(--accent); font-size: 0.78rem; font-weight: 600; letter-spacing: 0.07em; text-transform: uppercase; }
+.project-description { margin: 1rem 0 0 calc(36% + 0.2rem); color: var(--text-muted); }
+.project-details { list-style: none; display: grid; gap: 0.25rem; margin: 0.8rem 0 0 calc(36% + 0.2rem); }
+.project-details li { color: var(--text-muted); font-size: 0.9rem; }
+.project-details li::before { content: '— '; color: var(--accent); }
+@media (max-width: 760px) { .entrepreneur-section { padding-top: 4rem; } .company-content, .project-head { grid-template-columns: 1fr; gap: 0.65rem; } .project-description, .project-details { margin-left: 0; } }

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -1,50 +1,8 @@
-.footer {
-  border-top: 1px solid rgba(173, 195, 255, 0.22);
-  margin-top: 4rem;
-  padding: 2.6rem 0 2.2rem;
-  background: linear-gradient(180deg, rgba(8, 12, 20, 0.1), rgba(8, 12, 20, 0.6));
-}
-
-.footer-inner {
-  text-align: center;
-}
-
-.footer-title {
-  font-family: 'Space Grotesk', sans-serif;
-  font-size: 1.2rem;
-  font-weight: 600;
-}
-
-.footer-actions {
-  display: flex;
-  justify-content: center;
-  gap: 0.8rem;
-  flex-wrap: wrap;
-  margin-top: 1rem;
-}
-
-.footer-actions a {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.48rem 0.85rem;
-  border-radius: 999px;
-  border: 1px solid rgba(173, 195, 255, 0.24);
-  background: rgba(122, 162, 255, 0.1);
-  color: var(--text-muted);
-  font-size: 0.88rem;
-  font-weight: 600;
-  transition: background-color var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
-}
-
-.footer-actions a:hover {
-  color: var(--text);
-  background: rgba(45, 226, 230, 0.18);
-  transform: translateY(-1px);
-}
-
-.footer-copy {
-  margin-top: 1rem;
-  color: var(--text-muted);
-  font-size: 0.86rem;
-}
+.footer { border-top: 1px solid var(--line); margin-top: 4rem; padding: 2.1rem 0; }
+.footer-inner { display: grid; grid-template-columns: 1fr auto; align-items: end; gap: 1rem 3rem; }
+.footer-title { font-family: var(--serif); font-size: 1.7rem; letter-spacing: -0.035em; }
+.footer-actions { display: flex; gap: 1.25rem; }
+.footer-actions a { color: var(--text-muted); font-size: 0.84rem; transition: color var(--transition-fast); }
+.footer-actions a:hover { color: var(--accent); }
+.footer-copy { grid-column: 1 / -1; color: var(--text-muted); font-size: 0.75rem; }
+@media (max-width: 760px) { .footer-inner { grid-template-columns: 1fr; } .footer-actions { flex-wrap: wrap; } }

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,93 +1,14 @@
-.header {
-  position: sticky;
-  top: 0;
-  z-index: 100;
-  backdrop-filter: blur(14px);
-  background: linear-gradient(to bottom, rgba(6, 10, 18, 0.78), rgba(6, 10, 18, 0.5));
-  border-bottom: 1px solid rgba(173, 195, 255, 0.22);
-}
-
-.nav {
-  min-height: 78px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.logo {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.62rem;
-  font-family: 'Space Grotesk', sans-serif;
-  font-size: 1.12rem;
-  font-weight: 700;
-  letter-spacing: 0.01em;
-  color: var(--text);
-}
-
-.logo-mark {
-  width: 11px;
-  height: 11px;
-  border-radius: 999px;
-  background: linear-gradient(130deg, var(--accent), var(--accent-warm));
-  box-shadow: 0 0 14px rgba(45, 226, 230, 0.8);
-}
-
-.nav-links {
-  list-style: none;
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.3rem;
-  border: 1px solid rgba(173, 195, 255, 0.24);
-  border-radius: 999px;
-  background: rgba(14, 21, 35, 0.5);
-}
-
-.nav-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.5rem 0.9rem;
-  border-radius: 999px;
-  color: var(--text-muted);
-  font-size: 0.9rem;
-  font-weight: 600;
-  transition: color var(--transition-fast), background-color var(--transition-fast), transform var(--transition-fast);
-}
-
-.nav-link:hover {
-  color: var(--text);
-  background: rgba(122, 162, 255, 0.18);
-  transform: translateY(-1px);
-}
-
-.nav-link.is-active {
-  color: #08101a;
-  background: linear-gradient(120deg, #7df4f7, var(--accent));
-}
-
-@media (max-width: 820px) {
-  .nav {
-    min-height: 70px;
-    flex-direction: column;
-    justify-content: center;
-    padding: 0.65rem 0;
-  }
-
-  .logo {
-    font-size: 1rem;
-  }
-
-  .nav-links {
-    width: 100%;
-    justify-content: space-between;
-    gap: 0.2rem;
-  }
-
-  .nav-link {
-    padding: 0.48rem 0.55rem;
-    font-size: 0.8rem;
-  }
+.header { border-bottom: 1px solid var(--line); background: rgba(247, 245, 239, 0.94); }
+.nav { min-height: 85px; display: flex; align-items: center; justify-content: space-between; gap: 2rem; }
+.logo { font-family: var(--serif); font-size: 1.75rem; letter-spacing: -0.055em; }
+.logo-mark { display: none; }
+.nav-links { list-style: none; display: flex; align-items: center; gap: 2.6rem; }
+.nav-link { display: inline-flex; padding: 0.2rem 0; color: var(--text); font-size: 0.92rem; border-bottom: 2px solid transparent; transition: color var(--transition-fast), border-color var(--transition-fast); }
+.nav-link:hover, .nav-link.is-active { color: var(--accent); }
+.nav-link.is-active { border-color: var(--accent); }
+@media (max-width: 760px) {
+  .nav { min-height: auto; flex-direction: column; align-items: flex-start; gap: 0.7rem; padding: 1.1rem 0; }
+  .nav-links { width: 100%; justify-content: space-between; gap: 0.5rem; }
+  .logo { font-size: 1.55rem; }
+  .nav-link { font-size: 0.78rem; }
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,9 +2,9 @@ import { NavLink } from 'react-router-dom'
 import './Header.css'
 
 const links = [
-  { to: '/', label: 'Introduction' },
+  { to: '/', label: 'About' },
   { to: '/career', label: 'Career' },
-  { to: '/blog', label: 'Blog' },
+  { to: '/blog', label: 'Writing' },
   { to: '/contact', label: 'Contact' },
 ]
 

--- a/src/components/InvestorSection.css
+++ b/src/components/InvestorSection.css
@@ -1,77 +1,18 @@
-.investor-section {
-  padding-top: 2rem;
-}
-
-.investor-content {
-  display: grid;
-  gap: 1.2rem;
-}
-
-.investments-section,
-.philosophy-section {
-  border: 1px solid var(--line);
-  border-radius: var(--radius-lg);
-  padding: 1.4rem;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02));
-}
-
-.investments-section h3,
-.philosophy-section h3 {
-  margin-bottom: 1rem;
-}
-
-.past-investments-heading {
-  margin-top: 1.4rem;
-}
-
-.investment-card.past {
-  opacity: 0.65;
-}
-
-.investments-grid,
-.quotes-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.8rem;
-}
-
-.investment-card,
-.quote-card {
-  padding: 1rem;
-}
-
-.investment-type {
-  font-size: 0.74rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--accent);
-  margin: 0.35rem 0 0.45rem;
-  font-weight: 700;
-}
-
-.investment-description,
-.philosophy-intro {
-  color: var(--text-muted);
-}
-
-.philosophy-intro {
-  margin-bottom: 1rem;
-}
-
-.quote {
-  color: #dfe9ff;
-  font-style: italic;
-}
-
-.quote-author {
-  margin-top: 0.7rem;
-  color: var(--accent-warm);
-  font-weight: 700;
-}
-
-@media (max-width: 820px) {
-  .investments-grid,
-  .quotes-grid {
-    grid-template-columns: 1fr;
-  }
-}
+.investor-section { padding-top: 6rem; }
+.investor-section .page-intro { margin-bottom: 3rem; }
+.investor-section .page-intro .section-label { margin-bottom: 1rem; }
+.investor-content { display: grid; gap: 4.5rem; }
+.investments-section, .philosophy-section { padding: 0; }
+.investments-section h3, .philosophy-section h3 { margin-bottom: 1.2rem; font-size: 2.35rem; }
+.past-investments-heading { margin-top: 3rem; }
+.investments-grid, .quotes-grid { border-top: 1px solid var(--line); }
+.investment-card { display: grid; grid-template-columns: minmax(170px, 0.5fr) 1fr; gap: 0.55rem 1.5rem; padding: 1.35rem 0; border-bottom: 1px solid var(--line); }
+.investment-card h4 { font-family: var(--sans); font-size: 1.05rem; font-weight: 600; letter-spacing: -0.02em; }
+.investment-type { grid-column: 2; color: var(--accent); font-size: 0.74rem; font-weight: 600; letter-spacing: 0.07em; text-transform: uppercase; }
+.investment-description, .philosophy-intro { grid-column: 2; color: var(--text-muted); font-size: 0.94rem; }
+.investment-card.past { opacity: 0.65; }
+.philosophy-intro { max-width: 620px; margin-bottom: 1.5rem; }
+.quote-card { display: grid; grid-template-columns: minmax(170px, 0.5fr) 1fr; gap: 1.5rem; padding: 1.35rem 0; border-bottom: 1px solid var(--line); }
+.quote { color: var(--text); font-family: var(--serif); font-size: 1.45rem; letter-spacing: -0.025em; }
+.quote-author { color: var(--accent); font-size: 0.8rem; font-weight: 600; }
+@media (max-width: 760px) { .investor-section { padding-top: 4rem; } .investment-card, .quote-card { grid-template-columns: 1fr; gap: 0.45rem; } .investment-type, .investment-description { grid-column: auto; } }

--- a/src/pages/Blog.css
+++ b/src/pages/Blog.css
@@ -1,71 +1,12 @@
-.blog-page {
-  padding: 2.2rem 0;
-}
-
-.blog-hero {
-  text-align: center;
-  padding: 4.6rem 0 2.2rem;
-}
-
-.blog-hero .section-label {
-  margin-bottom: 1rem;
-}
-
-.blog-hero .subtitle {
-  color: var(--text-muted);
-  max-width: 680px;
-  margin: 1rem auto 0;
-}
-
-.blog-posts {
-  padding-top: 0.6rem;
-}
-
-.teaser-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.95rem;
-}
-
-.teaser-card {
-  padding: 1.2rem;
-  transition: transform var(--transition-base), border-color var(--transition-base);
-}
-
-.teaser-card:hover {
-  transform: translateY(-4px);
-  border-color: rgba(255, 159, 104, 0.48);
-}
-
-.teaser-tag {
-  display: inline-flex;
-  border-radius: 999px;
-  padding: 0.24rem 0.6rem;
-  border: 1px solid rgba(255, 159, 104, 0.42);
-  background: rgba(255, 159, 104, 0.12);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: #ffd7bf;
-}
-
-.teaser-card h3 {
-  margin-top: 0.82rem;
-  min-height: 4.4rem;
-}
-
-.teaser-meta {
-  margin-top: 0.8rem;
-  color: var(--text-muted);
-}
-
-@media (max-width: 980px) {
-  .teaser-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .teaser-card h3 {
-    min-height: 0;
-  }
-}
+.blog-page { padding: 0 0 2rem; }
+.blog-hero { padding: 7rem 0 4rem; }
+.blog-hero .section-label { margin-bottom: 1rem; }
+.blog-hero .subtitle { max-width: 520px; margin-top: 1.5rem; color: var(--text-muted); }
+.blog-posts { padding-top: 0; }
+.teaser-grid { border-top: 1px solid var(--line); }
+.teaser-card { display: grid; grid-template-columns: 150px 1fr auto; align-items: baseline; gap: 1.2rem; padding: 1.45rem 0; border-bottom: 1px solid var(--line); transition: color var(--transition-fast); }
+.teaser-card:hover { color: var(--accent); }
+.teaser-tag { color: var(--accent); font-size: 0.72rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; }
+.teaser-card h3 { font-family: var(--serif); font-size: clamp(1.55rem, 2.5vw, 2.2rem); }
+.teaser-meta { color: var(--text-muted); font-size: 0.8rem; }
+@media (max-width: 760px) { .blog-hero { padding: 5.5rem 0 3rem; } .teaser-card { grid-template-columns: 1fr; gap: 0.5rem; } }

--- a/src/pages/Contact.css
+++ b/src/pages/Contact.css
@@ -1,52 +1,11 @@
-.contact-page {
-  padding: 2rem 0;
-}
-
-.contact-hero {
-  text-align: center;
-  padding: 4.2rem 0 1.8rem;
-}
-
-.contact-hero .section-label {
-  margin-bottom: 1rem;
-}
-
-.contact-subtitle {
-  max-width: 700px;
-  margin: 1rem auto 0;
-  color: var(--text-muted);
-}
-
-.contact-content {
-  padding-top: 0.5rem;
-}
-
-.contact-card {
-  max-width: 720px;
-  margin: 0 auto;
-  padding: 1.6rem;
-  text-align: center;
-}
-
-.contact-card h3 {
-  margin-bottom: 0.85rem;
-}
-
-.contact-email a {
-  font-family: 'Space Grotesk', sans-serif;
-  font-size: 1.2rem;
-  color: var(--accent);
-}
-
-.contact-location {
-  margin-top: 0.5rem;
-  color: var(--text-muted);
-}
-
-.contact-actions {
-  display: flex;
-  justify-content: center;
-  gap: 0.68rem;
-  margin-top: 1.15rem;
-  flex-wrap: wrap;
-}
+.contact-page { padding: 0 0 2rem; }
+.contact-hero { padding: 7rem 0 3rem; }
+.contact-hero .section-label { margin-bottom: 1rem; }
+.contact-subtitle { max-width: 530px; margin-top: 1.4rem; color: var(--text-muted); }
+.contact-content { padding-top: 0; }
+.contact-card { max-width: none; padding: 2.4rem 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.contact-card h3 { font-size: 2.2rem; }
+.contact-email { margin-top: 1rem; }
+.contact-email a { font-family: var(--serif); font-size: clamp(1.8rem, 4vw, 3.2rem); letter-spacing: -0.04em; border-bottom: 1px solid currentColor; }
+.contact-location { margin-top: 0.8rem; color: var(--text-muted); }
+.contact-actions { display: flex; gap: 1.4rem; margin-top: 2rem; flex-wrap: wrap; }

--- a/src/pages/Introduction.css
+++ b/src/pages/Introduction.css
@@ -1,114 +1,12 @@
-.introduction-page {
-  padding: 2rem 0 3.2rem;
-}
-
-.intro-hero {
-  text-align: center;
-  padding: 5.4rem 1.4rem 4rem;
-  position: relative;
-  isolation: isolate;
-}
-
-.intro-hero::before,
-.intro-hero::after {
-  content: '';
-  position: absolute;
-  border-radius: 999px;
-  filter: blur(40px);
-  z-index: -1;
-}
-
-.intro-hero::before {
-  width: 300px;
-  height: 300px;
-  background: rgba(45, 226, 230, 0.22);
-  left: 2%;
-  top: 4%;
-}
-
-.intro-hero::after {
-  width: 260px;
-  height: 260px;
-  background: rgba(255, 159, 104, 0.2);
-  right: 3%;
-  bottom: 8%;
-}
-
-.intro-hero .section-label {
-  margin-bottom: 1.25rem;
-}
-
-.intro-tagline {
-  font-size: clamp(1.1rem, 2vw, 1.46rem);
-  margin-top: 1rem;
-  color: #d7e4ff;
-  font-weight: 600;
-}
-
-.intro-description {
-  max-width: 760px;
-  margin: 1rem auto 0;
-  color: var(--text-muted);
-  font-size: 1.05rem;
-}
-
-.intro-actions {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 1.8rem;
-}
-
-.intro-identities {
-  padding-top: 0.8rem;
-}
-
-.identity-cards {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.identity-card {
-  padding: 1.55rem;
-  transition: transform var(--transition-base), border-color var(--transition-base), background-color var(--transition-base);
-}
-
-.identity-card:hover {
-  transform: translateY(-5px);
-  border-color: rgba(45, 226, 230, 0.5);
-  background: linear-gradient(160deg, rgba(45, 226, 230, 0.12), rgba(255, 255, 255, 0.04));
-}
-
-.identity-badge {
-  display: inline-flex;
-  padding: 0.24rem 0.62rem;
-  border-radius: 999px;
-  background: rgba(122, 162, 255, 0.2);
-  border: 1px solid rgba(122, 162, 255, 0.35);
-  color: #dae6ff;
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.identity-card h3 {
-  margin-top: 0.95rem;
-  margin-bottom: 0.7rem;
-}
-
-.identity-card p {
-  color: var(--text-muted);
-}
-
-@media (max-width: 980px) {
-  .identity-cards {
-    grid-template-columns: 1fr;
-  }
-
-  .intro-hero {
-    padding-top: 4.4rem;
-  }
-}
+.introduction-page { padding: 0 0 3rem; }
+.intro-hero { max-width: 930px; padding: clamp(7rem, 15vw, 11rem) 0 6.5rem; }
+.intro-hero .section-label { margin-bottom: 1.3rem; }
+.intro-hero h1 { max-width: 800px; }
+.intro-tagline { max-width: 790px; margin-top: 1.55rem; font-family: var(--serif); font-size: clamp(2rem, 4vw, 3.6rem); letter-spacing: -0.045em; line-height: 1.04; }
+.intro-description { max-width: 510px; margin-top: 2rem; color: var(--text-muted); font-size: 1rem; }
+.intro-actions { display: flex; gap: 1.8rem; margin-top: 2.2rem; }
+.intro-identities { display: flex; align-items: baseline; gap: 0.8rem; border-top: 1px solid var(--line); padding: 1.3rem 0; }
+.current-label { color: var(--text-muted); font-size: 0.72rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; }
+.current-role { font-family: var(--serif); font-size: 1.4rem; letter-spacing: -0.03em; }
+.current-role span { color: var(--accent); }
+@media (max-width: 760px) { .intro-hero { padding: 5.8rem 0 4.2rem; } .intro-actions { gap: 1.1rem; } .intro-identities { display: block; } .current-role { margin-top: 0.35rem; } }

--- a/src/pages/Introduction.jsx
+++ b/src/pages/Introduction.jsx
@@ -1,58 +1,30 @@
 import './Introduction.css'
 
-const identities = [
-  {
-    title: 'Engineer',
-    summary: 'Architecting large-scale distributed systems and LLM-powered AI products across Big Tech and startups.',
-    badge: 'Systems + AI',
-  },
-  {
-    title: 'Investor',
-    summary: 'Backing high-conviction opportunities with a long-term value lens.',
-    badge: 'Long-Term Capital',
-  },
-  {
-    title: 'Entrepreneur',
-    summary: 'Creating ventures that deliver measurable value to real people.',
-    badge: 'Tianyang LLC',
-  },
-]
-
 function Introduction() {
   return (
     <div className="introduction-page">
       <div className="container">
         <section className="intro-hero reveal">
-          <span className="section-label">Personal HQ</span>
+          <span className="section-label">Independent engineer · investor · builder</span>
           <h1>Tianyang Che</h1>
-          <p className="intro-tagline">Large-Scale System Architect · Platform/Product Builder · AI & Distributed Systems</p>
+          <p className="intro-tagline">I build systems that make ambitious ideas real.</p>
           <p className="intro-description">
-            10+ years shipping high-impact software at Meta, Amazon, Coupang, and Auger. I architect distributed systems, build LLM-powered products, and invest with a long-term lens.
+            An AI engineer focused on thoughtful systems, durable products, and the teams that bring them to life.
           </p>
 
           <div className="intro-actions">
-            <a className="btn btn-primary" href="mailto:tianyangche@gmail.com">
-              Email Me
+            <a className="btn btn-primary" href="/career">
+              View career
             </a>
-            <a className="btn btn-secondary" href="https://www.linkedin.com/in/tianyangche/" target="_blank" rel="noreferrer">
-              LinkedIn
-            </a>
-            <a className="btn btn-ghost" href="https://github.com/tianyangche" target="_blank" rel="noreferrer">
-              GitHub
+            <a className="btn btn-ghost" href="/blog">
+              Read notes
             </a>
           </div>
         </section>
 
         <section className="intro-identities reveal">
-          <div className="identity-cards">
-            {identities.map((identity) => (
-              <article key={identity.title} className="identity-card surface">
-                <p className="identity-badge">{identity.badge}</p>
-                <h3>{identity.title}</h3>
-                <p>{identity.summary}</p>
-              </article>
-            ))}
-          </div>
+          <p className="current-label">Currently</p>
+          <p className="current-role">NVIDIA <span>—</span> AI Engineer</p>
         </section>
       </div>
     </div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,235 +1,95 @@
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Manrope:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600&family=Newsreader:opsz,wght@6..72,400;6..72,500&display=swap');
 
 :root {
-  --bg: #090c12;
-  --bg-elevated: #121823;
-  --surface: rgba(255, 255, 255, 0.06);
-  --surface-strong: rgba(255, 255, 255, 0.1);
-  --text: #edf2ff;
-  --text-muted: #a9b5d6;
-  --line: rgba(173, 195, 255, 0.22);
-  --accent: #2de2e6;
-  --accent-warm: #ff9f68;
-  --accent-2: #7aa2ff;
-  --success: #4ade80;
-  --max-width: 1160px;
-  --radius-sm: 10px;
-  --radius-md: 18px;
-  --radius-lg: 28px;
-  --shadow: 0 18px 40px rgba(0, 0, 0, 0.32);
-  --shadow-soft: 0 8px 24px rgba(0, 0, 0, 0.22);
-  --transition-fast: 180ms ease;
-  --transition-base: 260ms ease;
+  --bg: #f7f5ef;
+  --bg-soft: #f0ede5;
+  --text: #25241f;
+  --text-muted: #6d6a61;
+  --line: #d9d5ca;
+  --accent: #35552f;
+  --accent-warm: #a34d39;
+  --success: #35552f;
+  --max-width: 1210px;
+  --serif: 'Newsreader', Georgia, serif;
+  --sans: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --transition-fast: 160ms ease;
 }
 
-html {
-  scroll-behavior: smooth;
-}
+html { scroll-behavior: smooth; }
 
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
+* { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
   min-height: 100vh;
-  font-family: 'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: var(--sans);
   color: var(--text);
-  background:
-    radial-gradient(circle at 10% 0%, rgba(45, 226, 230, 0.18), transparent 32%),
-    radial-gradient(circle at 90% 10%, rgba(122, 162, 255, 0.18), transparent 28%),
-    linear-gradient(165deg, #090c12 0%, #0d1220 48%, #0b1019 100%);
-  line-height: 1.65;
+  background: var(--bg);
+  line-height: 1.55;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  background-image: linear-gradient(rgba(255, 255, 255, 0.028) 1px, transparent 1px), linear-gradient(90deg, rgba(255, 255, 255, 0.028) 1px, transparent 1px);
-  background-size: 34px 34px;
-  mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.95), transparent 84%);
+.app { min-height: 100vh; display: flex; flex-direction: column; }
+main { flex: 1; }
+
+.container { width: min(var(--max-width), calc(100% - 5rem)); margin: 0 auto; }
+section { padding: 5.5rem 0; }
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--serif);
+  font-weight: 400;
+  letter-spacing: -0.045em;
+  line-height: 0.98;
 }
 
-.app {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  position: relative;
-}
+h1 { font-size: clamp(4rem, 8vw, 7.25rem); }
+h2 { font-size: clamp(3rem, 5vw, 5.35rem); }
+h3 { font-size: clamp(1.35rem, 2vw, 1.85rem); }
 
-main {
-  flex: 1;
-}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; color: inherit; }
 
-.container {
-  width: min(var(--max-width), 100% - 2.5rem);
-  margin: 0 auto;
-}
-
-section {
-  padding: 4.5rem 0;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-family: 'Space Grotesk', 'Manrope', sans-serif;
-  font-weight: 600;
-  letter-spacing: -0.02em;
-  line-height: 1.15;
-}
-
-h1 {
-  font-size: clamp(2.3rem, 5vw, 4.15rem);
-}
-
-h2 {
-  font-size: clamp(1.8rem, 3.4vw, 2.8rem);
-}
-
-h3 {
-  font-size: clamp(1.25rem, 2.1vw, 1.75rem);
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-button {
-  font-family: inherit;
-  color: inherit;
-}
-
-.page-intro {
-  text-align: center;
-  margin-bottom: 2.5rem;
-}
-
-.page-intro p {
-  max-width: 740px;
-  margin: 0.9rem auto 0;
-  color: var(--text-muted);
-}
+.page-intro { margin-bottom: 4.2rem; text-align: left; }
+.page-intro p { max-width: 650px; margin-top: 1.4rem; color: var(--text-muted); font-size: 1rem; }
 
 .section-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.55rem;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  padding: 0.45rem 0.9rem;
-  color: var(--text-muted);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  display: block;
+  color: var(--accent);
+  font-family: var(--sans);
   font-size: 0.72rem;
-  font-weight: 700;
+  font-weight: 600;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
 }
 
-.section-label::before {
-  content: '';
-  width: 7px;
-  height: 7px;
-  border-radius: 999px;
-  background: linear-gradient(135deg, var(--accent), var(--accent-2));
-  box-shadow: 0 0 12px rgba(45, 226, 230, 0.65);
-}
-
-.surface {
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.03));
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-soft);
-  backdrop-filter: blur(8px);
-}
+.section-label::before { display: none; }
+.surface { background: transparent; border: 0; border-radius: 0; box-shadow: none; }
 
 .btn {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  padding: 0.82rem 1.3rem;
-  font-weight: 700;
-  font-size: 0.95rem;
-  transition: transform var(--transition-base), box-shadow var(--transition-base), background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
-}
-
-.btn:hover {
-  transform: translateY(-2px);
-}
-
-.btn-primary {
-  color: #061019;
-  background: linear-gradient(120deg, var(--accent), #7df4f7);
-  box-shadow: 0 8px 24px rgba(45, 226, 230, 0.36);
-}
-
-.btn-primary:hover {
-  box-shadow: 0 12px 28px rgba(45, 226, 230, 0.44);
-}
-
-.btn-secondary {
-  background: rgba(122, 162, 255, 0.16);
-  border-color: rgba(122, 162, 255, 0.38);
+  gap: 0.55rem;
+  border-bottom: 1px solid currentColor;
+  padding: 0.18rem 0;
   color: var(--text);
+  font-size: 0.94rem;
+  font-weight: 500;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
 }
 
-.btn-secondary:hover {
-  background: rgba(122, 162, 255, 0.24);
-}
+.btn::after { content: '↗'; font-size: 1rem; }
+.btn:hover { color: var(--accent); }
+.btn-primary, .btn-secondary, .btn-ghost { background: transparent; border-radius: 0; box-shadow: none; }
 
-.btn-ghost {
-  background: transparent;
-  border-color: var(--line);
-  color: var(--text-muted);
-}
+.reveal { animation: fade-up 520ms ease both; }
+@keyframes fade-up { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
 
-.btn-ghost:hover {
-  color: var(--text);
-  border-color: rgba(173, 195, 255, 0.45);
-}
-
-@keyframes fade-up {
-  from {
-    opacity: 0;
-    transform: translateY(18px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.reveal {
-  animation: fade-up 560ms var(--transition-base) both;
-}
-
-@media (max-width: 820px) {
-  section {
-    padding: 3.2rem 0;
-  }
-
-  .container {
-    width: min(var(--max-width), 100% - 1.3rem);
-  }
+@media (max-width: 760px) {
+  .container { width: min(var(--max-width), calc(100% - 2.4rem)); }
+  section { padding: 3.7rem 0; }
+  .page-intro { margin-bottom: 2.8rem; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation: none !important;
-    transition: none !important;
-    scroll-behavior: auto !important;
-  }
+  *, *::before, *::after { animation: none !important; transition: none !important; scroll-behavior: auto !important; }
 }


### PR DESCRIPTION
## Summary

- Replace the dark, neon visual system with a warm editorial light theme.
- Redesign the career timeline around serif typography, restrained metadata, and thin dividers.
- Carry the new system through the home, writing, contact, investor, and venture views.
- Add visual QA evidence for the selected design direction.

## Why

The previous visual language felt overly AI-focused and visually busy. This redesign makes the personal site feel calmer, more timeless, and easier to read.

## Validation

- `npm run build`
- `git diff --check`
- Browser-verified desktop and mobile Career views
- About → Career navigation
- Visual QA: `design-qa.md`